### PR TITLE
remove option "--depth 1"

### DIFF
--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -54,7 +54,7 @@ fi
 if [ ! -d "$APP_ROOT/libraries/webwork-open-problem-library/OpenProblemLibrary" ]; then
   echo "Installing the OPL - This takes time - please be patient."
   cd $APP_ROOT/libraries/
-  /usr/bin/git clone -v --progress --single-branch --branch master --depth 1 https://github.com/openwebwork/webwork-open-problem-library.git
+  /usr/bin/git clone -v --progress --single-branch --branch master https://github.com/openwebwork/webwork-open-problem-library.git
 
   # FIXME / TO-DO : Download a saved version of the OPL sql table data to be loaded and extract
   #    it in the appropriate location.This would avoid the need for a length run of OPL-update.


### PR DESCRIPTION
This will later on help to automatically create releases of the OPL.

The difference in size is currently not  not huge (1.4 GB without the `--depth 1` option vs. 1.1 GB with it). I hope we can afford that.